### PR TITLE
Add documentation for resolving tag issues

### DIFF
--- a/docs/reference/config-yml-reference.md
+++ b/docs/reference/config-yml-reference.md
@@ -49,6 +49,22 @@ page.
 
 [yaml]: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
 
+:::tip Notice
+
+If you are editing YAML in VS Code and using `!secret` references, you will get "Unknown Tag"
+errors. Remove them by adding the following to VS Code's `settings.json` file ([VS Code
+Documentation][vscode_settings]):
+
+```json
+  "yaml.customTags": [
+    "!secret scalar"
+  ]
+```
+
+:::
+
+[vscode_settings]: https://code.visualstudio.com/docs/getstarted/settings
+
 ## All Services
 
 The below settings are applicable to both Sonarr and Radarr.


### PR DESCRIPTION
If you are using VS Code, yaml schemas, and secrets -- then you will get an "Unknown Tag" error on secrets values. Unfortunately, the json schema doesn't currently support YAML tags.  To remove these errors, you need to add an additional setting for the VSCode yaml extension.  This adds documentation to tell users how to set that up.