### PR TITLE
docs(config_examples): :memo: Update to include named instances

### DIFF
--- a/docs/reference/configuration-examples.md
+++ b/docs/reference/configuration-examples.md
@@ -18,7 +18,8 @@ example refers to sensitive values by [using a `secrets.yml` file](secrets-refer
 
 ```yml
 sonarr:
-  - base_url: !secret sonarr_url
+  sonarr:
+    base_url: !secret sonarr_url
     api_key: !secret sonarr_apikey
     quality_definition: hybrid
     release_profiles:
@@ -30,7 +31,8 @@ sonarr:
         tags: [tv]
 
 radarr:
-  - base_url: !secret radarr_url
+  radarr:
+    base_url: !secret radarr_url
     api_key: !secret radarr_apikey
     quality_definition:
       type: movie
@@ -62,7 +64,8 @@ Simply create two YAML files:
 
 ```yml
 sonarr:
-  - base_url: http://localhost:8989
+  sonarr:
+    base_url: http://localhost:8989
     api_key: f7e74ba6c80046e39e076a27af5a8444
     release_profiles:
       - trash_ids:
@@ -75,7 +78,8 @@ sonarr:
 
 ```yml
 sonarr:
-  - base_url: http://localhost:8989
+  sonarr:
+    base_url: http://localhost:8989
     api_key: f7e74ba6c80046e39e076a27af5a8444
     quality_definition: hybrid
 ```
@@ -96,9 +100,9 @@ recyclarr sonarr --config sonarr-release-profiles.yml sonarr-quality-definition.
 
 ## Update Sonarr v3 and v4 instances in a single YAML config
 
-:::danger
+:::caution
 
-Custom Formats are only supported in Sonarr v4 which <u>**is prerelease software**</u>!
+Custom Formats are only supported in Sonarr v4 which <u>is **beta** software</u>!
 
 If you are new to the TRaSH Guides, I highly recommend you start with Sonarr v3 Release Profiles
 instead.
@@ -111,7 +115,8 @@ property:
 
 ```yml
 sonarr:
-  - base_url: http://sonarr_v4:8989
+  sonarr_v4:
+    base_url: http://sonarr_v4:8989
     api_key: f7e74ba6c80046e39e076a27af5a8444
     quality_definition: anime
     custom_formats:
@@ -121,7 +126,8 @@ sonarr:
           - 096e406c92baa713da4a72d88030b815 # Anime BD Tier 03 (SeaDex Muxers)
         quality_profiles:
           - name: Anime Subs
-  - base_url: http://sonarr_v3:8989
+  sonarr_v3:
+    base_url: http://sonarr_v3:8989
     api_key: bf99da49d0b0488ea34e4464aa63a0e5
     quality_definition: series
     release_profiles:
@@ -149,7 +155,8 @@ Solution:
 
 ```yml
 radarr:
-  - base_url: http://localhost:7878
+  radarr:
+    base_url: http://localhost:7878
     api_key: 87674e2c316645ed85696a91a3d41988
 
     custom_formats:
@@ -183,7 +190,8 @@ Solution:
 
 ```yml
 radarr:
-  - base_url: http://localhost:7878
+  radarr:
+    base_url: http://localhost:7878
     api_key: 87674e2c316645ed85696a91a3d41988
 
     custom_formats:
@@ -220,7 +228,8 @@ You can assign custom format scores (from the guide) to multiple profiles (all t
 
 ```yml
 radarr:
-  - base_url: http://localhost:7878
+  radarr:
+    base_url: http://localhost:7878
     api_key: 87674e2c316645ed85696a91a3d41988
 
     custom_formats:
@@ -242,7 +251,8 @@ You can also choose to override the score (for all custom formats!) in one profi
 
 ```yml
 radarr:
-  - base_url: http://localhost:7878
+  radarr:
+    base_url: http://localhost:7878
     api_key: 87674e2c316645ed85696a91a3d41988
 
     custom_formats:
@@ -266,7 +276,8 @@ zero."*
 
 ```yml
 radarr:
-  - base_url: http://localhost:7878
+  radarr:
+    base_url: http://localhost:7878
     api_key: 87674e2c316645ed85696a91a3d41988
 
     custom_formats:

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.2.0",
-    "@docusaurus/preset-classic": "2.2.0",
+    "@docusaurus/core": "^2.2.0",
+    "@docusaurus/preset-classic": "^2.2.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1198,7 +1198,7 @@
     "@docsearch/css" "3.2.1"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.2.0":
+"@docusaurus/core@2.2.0", "@docusaurus/core@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.2.0.tgz#64c9ee31502c23b93c869f8188f73afaf5fd4867"
   integrity sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==
@@ -1435,7 +1435,7 @@
     sitemap "^7.1.1"
     tslib "^2.4.0"
 
-"@docusaurus/preset-classic@2.2.0":
+"@docusaurus/preset-classic@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz#bece5a043eeb74430f7c6c7510000b9c43669eb7"
   integrity sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==


### PR DESCRIPTION
Update config examples to include named instances.
Change Sonarr V4 from being pre-release to beta.
Change Sonarr V4 from danger to caution.
  - Didn't think it was as big of a need to warn as it is beta now.