### PR TITLE
config templates: Hide ToC and use navbar link

### DIFF
--- a/docs/guide-configs.md
+++ b/docs/guide-configs.md
@@ -1,6 +1,8 @@
 ---
 id: guide-configs
 title: Pre-Built Configuration Files
+sidebar_class_name: hidden # It's in the nav title bar
+hide_table_of_contents: true
 ---
 
 Below you will find pre-built configuration files for the following TRaSH Guides quality profiles:

--- a/docs/guide-configs.md
+++ b/docs/guide-configs.md
@@ -188,7 +188,7 @@ https://github.com/recyclarr/config-templates/blob/master/radarr/french-remux-we
 
 ---
 
-## Sonarr V4
+## Sonarr v4
 
 ### WEB-1080p {#web-1080p-v4}
 

--- a/docs/sqp-configs.md
+++ b/docs/sqp-configs.md
@@ -2,6 +2,7 @@
 id: sqp-configs
 title: Pre-Built SQP Configuration Files
 sidebar_class_name: hidden
+hide_table_of_contents: true
 ---
 
 Below you will find pre-built configuration files for the following TRaSH Guides SQPs:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,6 +89,11 @@ const config = {
             label: 'Wiki',
           },
           {
+            type: 'doc',
+            docId: 'guide-configs',
+            label: 'Config Templates'
+          },
+          {
             href: `https://${otherInfo.hostname}/wiki`,
             target: '_self',
             position: 'right',


### PR DESCRIPTION
For the templates pages, hide the Table of Contents on the right (since there are tables for navigation already).

Also use a navbar (top) link to access the templates.