### PR TITLE
Add section about privilege escalation prevention

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -329,14 +329,14 @@ services:
 
 ### Prevent in-container privilege escalation
 
-For additional security, you may [run Recyclarr with `--security-opt=no-new-privileges`][security_opt]
-in order to prevent privilege escalation. This will prevent the container from potentially gaining new
-privileges via `setuid` and `setgid` binaries, like `su` and `sudo`.
-To do this in Docker Compose, you need to add the `security_opt: ['no-new-privileges:true']` setting
-to your service configuration.
+For additional security, you may [run Recyclarr with
+`--security-opt=no-new-privileges`][security_opt] in order to prevent privilege escalation. This
+will prevent the container from potentially gaining new privileges via `setuid` and `setgid`
+binaries, like `su` and `sudo`.
 
-Using the example `docker-compose.yml` presented at the start of this page, make the following
-modification:
+To do this in Docker Compose, you need to add the `security_opt: ['no-new-privileges:true']` setting
+to your service configuration. Using the example `docker-compose.yml` presented at the start of this
+page, make the following modification:
 
 ```yml
 services:

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -342,7 +342,7 @@ page, make the following modification:
 services:
   recyclarr:
     image: ghcr.io/recyclarr/recyclarr
-    security_opt: ['no-new-privileges:true']
+    security_opt: ['no-new-privileges:true'] # Add this line
     # ...
 ```
 

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -327,4 +327,24 @@ services:
     # ...
 ```
 
+### Prevent in-container privilege escalation
+
+For additional security, you may [run Recyclarr with `--security-opt=no-new-privileges`][security_opt]
+in order to prevent privilege escalation. This will prevent the container from potentially gaining new
+privileges via `setuid` and `setgid` binaries, like `su` and `sudo`.
+To do this in Docker Compose, you need to add the `security_opt: ['no-new-privileges:true']` setting
+to your service configuration.
+
+Using the example `docker-compose.yml` presented at the start of this page, make the following
+modification:
+
+```yml
+services:
+  recyclarr:
+    image: ghcr.io/recyclarr/recyclarr
+    security_opt: ['no-new-privileges:true']
+    # ...
+```
+
 [read_only]: https://docs.docker.com/reference/cli/docker/container/run/#read-only
+[security_opt]: https://docs.docker.com/reference/cli/docker/container/run/#security-opt


### PR DESCRIPTION
After I read a few Docker security guides and applied them to my personal setup, I thought I'd spread the word about a few of these best-practices.
Since Recyclarr already uses or suggests a few proper practices about user creation and read-only filesystems (even if I'd use `10000:10001` for the default UID/GID instead of `1000:1000`, but that's something for a different discussion), I thought I'd extend the wiki with one more good practice: Adding the `no-new-privileges` security option.

Some info about this can be found here:
- [Docker Capabilities and no-new-privileges](https://raesene.github.io/blog/2019/06/01/docker-capabilities-and-no-new-privs/)
- [Docker Security - OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-4-prevent-in-container-privilege-escalation)
- [docker run | Docker Docs](https://docs.docker.com/reference/cli/docker/container/run/#security-opt)

Basically, adding `--security-opt=no-new-privileges` prevents any potential privilege escalation. I don't think the Recyclarr image will ever be prone to this problem, but since the `su` command exists I'd say better safe than sorry.

Btw, I thought about adding another section about limiting container capabilities using `--cap-add` and `--cap-drop`, but finding out which capabilities Recyclarr actually needs is way more work than adding this one single security option. Maybe I'll do it in the future once I figure it out for my own setup. But probably not. I guess one way to do it is running all the unit tests in a container with `--cap-drop=all` and see if it fails, fix it, run it again, and so on.