### PR TITLE
docs: add Files as substitution method

### DIFF
--- a/docs/reference/configuration/value-substitution.mdx
+++ b/docs/reference/configuration/value-substitution.mdx
@@ -7,12 +7,13 @@ Recyclarr supports substituting dynamic values into your configuration YAML file
 sensitive data like API keys out of your config files and enables configuration sharing without
 manual redaction.
 
-Two substitution methods are available:
+Three substitution methods are available:
 
 - **Secrets**: Values stored in a `secrets.yml` file
 - **Environment Variables**: Values from your shell environment
+- **Files**: Values read directly from an external file
 
-Both use YAML tags to substitute values at runtime.
+All use YAML tags to substitute values at runtime.
 
 ## Secrets {/*#secrets*/}
 
@@ -139,6 +140,33 @@ Quotes around defaults are stripped (but not required for spaces):
 # Results in: my default value
 ```
 
+## Files {/*#files*/}
+
+Files allows you to substitute the text contents of an external file.
+
+:::note[Version Requirement]
+
+File substitution was introduced in `v7.5.0`.
+
+:::
+
+### Usage {/*#files-usage*/}
+Reference files in your configuration using `!file /path/to/filename`:
+
+```yml
+radarr:
+  movies:
+    base_url: !file /run/secrets/radarr_url
+    api_key: !file /run/secrets/radarr_api_key
+```
+
+:::warning
+
+Recyclarr fails to load configuration if the specified file does not exist,
+or if Recyclarr lacks the permissions to read the file
+
+:::
+
 ## Choosing a Method {/*#comparison*/}
 
 Use **secrets** when:
@@ -152,3 +180,9 @@ Use **environment variables** when:
 - Running in containers or Kubernetes where env vars are standard
 - You need default fallback values
 - You want to avoid managing an extra file
+
+Use **files** when:
+
+- You are utilizing Docker or Kubernetes Secrets mounted as files
+- You want to centralize and share values across multiple different applications
+from a single source file

--- a/docs/reference/configuration/value-substitution.mdx
+++ b/docs/reference/configuration/value-substitution.mdx
@@ -163,7 +163,7 @@ radarr:
 :::warning
 
 Recyclarr fails to load configuration if the specified file does not exist,
-or if Recyclarr lacks the permissions to read the file
+or if Recyclarr lacks the permissions to read the file.
 
 :::
 

--- a/docs/reference/configuration/value-substitution.mdx
+++ b/docs/reference/configuration/value-substitution.mdx
@@ -142,7 +142,11 @@ Quotes around defaults are stripped (but not required for spaces):
 
 ## Files {/*#files*/}
 
-Files allows you to substitute the text contents of an external file.
+Read the entire contents of a file and use it as a YAML value. This is useful when secrets are
+managed as individual files, such as [Docker secrets][docker-secrets] or Kubernetes secrets mounted
+at `/run/secrets/`.
+
+[docker-secrets]: https://docs.docker.com/compose/how-tos/use-secrets/
 
 :::note[Version Requirement]
 
@@ -150,8 +154,16 @@ File substitution was introduced in `v7.5.0`.
 
 :::
 
+### Syntax {/*#files-syntax*/}
+
+```yml
+!file /path/to/file
+```
+
+The path can be absolute or relative. Relative paths resolve from the [application data
+directory][appdata].
+
 ### Usage {/*#files-usage*/}
-Reference files in your configuration using `!file /path/to/filename`:
 
 ```yml
 radarr:
@@ -162,8 +174,7 @@ radarr:
 
 :::warning
 
-Recyclarr fails to load configuration if the specified file does not exist,
-or if Recyclarr lacks the permissions to read the file.
+Recyclarr fails to load configuration if the file does not exist or cannot be read.
 
 :::
 
@@ -183,6 +194,5 @@ Use **environment variables** when:
 
 Use **files** when:
 
-- You are utilizing Docker or Kubernetes Secrets mounted as files
-- You want to centralize and share values across multiple different applications
-from a single source file
+- Secrets are mounted as individual files (Docker secrets, Kubernetes secrets)
+- You want to share a single secret file across multiple applications


### PR DESCRIPTION
This PR adds documentation for the new !file tag substitution method, as requested in recyclarr/recyclarr#278.